### PR TITLE
[AME-2787] Set organisation with environment variable

### DIFF
--- a/acloud/data_source_cloud_account.go
+++ b/acloud/data_source_cloud_account.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/avisi-cloud/go-client/pkg/acloudapi"
 )
 
 func dataSourceCloudAccount() *schema.Resource {
@@ -30,7 +28,7 @@ func dataSourceCloudAccount() *schema.Resource {
 			},
 			"organisation": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Slug of the Organisation",
 			},
 			"cloud_provider": {
@@ -48,8 +46,12 @@ func dataSourceCloudAccount() *schema.Resource {
 }
 
 func dataCloudAccountRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
-	org := d.Get("organisation").(string)
+	provider := getProvider(m)
+	client := provider.Client
+	org, err := getOrganisation(provider, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	displayName := d.Get("display_name").(string)
 	cloudProvider := d.Get("cloud_provider").(string)
 

--- a/acloud/data_source_cloud_provider_node_types.go
+++ b/acloud/data_source_cloud_provider_node_types.go
@@ -50,7 +50,8 @@ func dataSourceCloudProviderNodeTypes() *schema.Resource {
 }
 
 func dataSourceCloudProviderNodeTypesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
+	provider := getProvider(m)
+	client := provider.Client
 
 	cloudProviderSlug := d.Get("cloud_provider").(string)
 

--- a/acloud/data_source_cluster.go
+++ b/acloud/data_source_cluster.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/avisi-cloud/go-client/pkg/acloudapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -24,7 +23,7 @@ func dataSourceCluster() *schema.Resource {
 			},
 			"organisation": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Slug of the Organisation of the Cluster",
 			},
 			"environment": {
@@ -80,9 +79,13 @@ func dataSourceCluster() *schema.Resource {
 }
 
 func dataClusterRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
+	provider := getProvider(m)
+	client := provider.Client
+	org, err := getOrganisation(provider, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	org := d.Get("organisation").(string)
 	env := d.Get("environment").(string)
 	slug := d.Get("slug").(string)
 

--- a/acloud/data_source_node_join_config.go
+++ b/acloud/data_source_node_join_config.go
@@ -25,7 +25,7 @@ This datasource only works for Bring Your Own Node clusters.
 			},
 			"organisation": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Slug of the Organisation",
 			},
 			"environment": {
@@ -71,13 +71,17 @@ This datasource only works for Bring Your Own Node clusters.
 }
 
 func dataSourceNodeJoinConfigRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
+	provider := getProvider(m)
+	client := provider.Client
+	org, err := getOrganisation(provider, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	organisationSlug := d.Get("organisation").(string)
 	environmentSlug := d.Get("environment").(string)
 	clusterSlug := d.Get("cluster").(string)
 
-	cluster, err := client.GetCluster(ctx, organisationSlug, environmentSlug, clusterSlug)
+	cluster, err := client.GetCluster(ctx, org, environmentSlug, clusterSlug)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/acloud/data_source_organisation.go
+++ b/acloud/data_source_organisation.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/avisi-cloud/go-client/pkg/acloudapi"
 )
 
 func dataSourceOrganisations() *schema.Resource {
@@ -25,7 +23,7 @@ func dataSourceOrganisations() *schema.Resource {
 			},
 			"slug": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"email": {
 				Type:     schema.TypeString,
@@ -36,13 +34,16 @@ func dataSourceOrganisations() *schema.Resource {
 }
 
 func dataSourceOrganisationsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
-
+	provider := getProvider(m)
+	client := provider.Client
+	slug, err := getOrganisation(provider, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	organisations, err := client.GetMemberships(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	slug := d.Get("slug")
 
 	for _, org := range organisations {
 		if org.Slug == slug {

--- a/acloud/data_source_update_channel.go
+++ b/acloud/data_source_update_channel.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/avisi-cloud/go-client/pkg/acloudapi"
 )
 
 func dataSourceUpdateChannel() *schema.Resource {
@@ -17,7 +15,7 @@ func dataSourceUpdateChannel() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"organisation": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Slug of the Organisation",
 			},
 			"name": {
@@ -40,10 +38,15 @@ func dataSourceUpdateChannel() *schema.Resource {
 }
 
 func dataSourceUpdateChannelRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
-	orgSlug := d.Get("organisation").(string)
+	provider := getProvider(m)
+	client := provider.Client
+	org, err := getOrganisation(provider, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	channelName := d.Get("name").(string)
-	updateChannels, err := client.GetUpdateChannels(ctx, orgSlug)
+	updateChannels, err := client.GetUpdateChannels(ctx, org)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to get update channel: %w", err))
 	}

--- a/acloud/resource_nodepool.go
+++ b/acloud/resource_nodepool.go
@@ -26,7 +26,7 @@ func resourceNodepool() *schema.Resource {
 			},
 			"organisation": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 				Description: "Slug of the Organisation. Can only be set on creation.",
 			},
@@ -150,7 +150,8 @@ func resourceNodepool() *schema.Resource {
 }
 
 func resourceNodepoolCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
+	provider := getProvider(m)
+	client := provider.Client
 
 	cluster, err := getClusterForNodePool(ctx, d, m)
 	if err != nil {
@@ -227,9 +228,13 @@ func castInterfaceMap(original map[string]interface{}) map[string]string {
 }
 
 func getClusterForNodePool(ctx context.Context, d *schema.ResourceData, m interface{}) (*acloudapi.Cluster, error) {
-	client := m.(acloudapi.Client)
+	provider := getProvider(m)
+	client := provider.Client
+	org, err := getOrganisation(provider, d)
+	if err != nil {
+		return nil, err
+	}
 
-	org := getStringAttributeWithLegacyName(d, "organisation", "organisation_slug")
 	env := getStringAttributeWithLegacyName(d, "environment", "environment_slug")
 	cls := getStringAttributeWithLegacyName(d, "cluster", "cluster_slug")
 
@@ -237,7 +242,8 @@ func getClusterForNodePool(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func resourceNodepoolRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
+	provider := getProvider(m)
+	client := provider.Client
 
 	cluster, err := getClusterForNodePool(ctx, d, m)
 	if err != nil {
@@ -277,7 +283,8 @@ func resourceNodepoolRead(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceNodepoolUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
+	provider := getProvider(m)
+	client := provider.Client
 
 	cluster, err := getClusterForNodePool(ctx, d, m)
 	if err != nil {
@@ -314,7 +321,9 @@ func resourceNodepoolUpdate(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func resourceNodepoolDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(acloudapi.Client)
+	provider := getProvider(m)
+	client := provider.Client
+
 	cluster, err := getClusterForNodePool(ctx, d, m)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("cluster was not found: %w", err))

--- a/examples/aws/example.tf
+++ b/examples/aws/example.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 variable "acloud_token" {
-  sensitive = true
+  sensitive   = true
   description = "Your Avisi Cloud Personal Access Token"
 }
 
@@ -30,33 +30,30 @@ variable "cloud_account_name" {
 }
 
 provider "acloud" {
-  token      = var.acloud_token
-  acloud_api = var.acloud_api
+  token        = var.acloud_token
+  acloud_api   = var.acloud_api
+  organisation = var.organisation
 }
 
 data "acloud_cloud_account" "demo" {
-  organisation   = var.organisation
   display_name   = var.cloud_account_name
   cloud_provider = "aws"
 }
 
 # Update channel that uses Kubernetes v1.28
 data "acloud_update_channel" "channel" {
-  organisation = var.organisation
-  name         = "v1.28"
+  name = "v1.28"
 }
 
 # Create a new environment
 resource "acloud_environment" "demo" {
-  name         = "terraform-test"
-  type         = "demo"
-  organisation = var.organisation
+  name = "terraform-test"
+  type = "demo"
 }
 
 # Demo cluster that uses the Kubernetes version from the previously defined Update Channel
 resource "acloud_cluster" "demo_cluster" {
   name                   = "tf-demo-cluster"
-  organisation           = var.organisation
   environment            = acloud_environment.demo.slug
   version                = data.acloud_update_channel.channel.version
   region                 = "eu-west-1"
@@ -65,7 +62,6 @@ resource "acloud_cluster" "demo_cluster" {
 
 # Example worker node pool that will be provisioned for the created cluster
 resource "acloud_nodepool" "workers" {
-  organisation          = var.organisation
   environment           = acloud_environment.demo.slug
   cluster               = acloud_cluster.demo_cluster.slug
   name                  = "workers"
@@ -79,8 +75,4 @@ resource "acloud_nodepool" "workers" {
   labels = {
     "role" = "worker"
   }
-}
-
-output "cluster_identity" {
-  value = acloud_cluster.identity
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/avisi-cloud/terraform-proivder-acloud
+module github.com/avisi-cloud/terraform-provider-acloud
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/avisi-cloud/terraform-proivder-acloud/acloud"
+	"github.com/avisi-cloud/terraform-provider-acloud/acloud"
 )
 
 func main() {


### PR DESCRIPTION
Adds the functionality to set the organisation slug with the TF_VAR_organisation environment variable. When this variable is set, the organisation slug field can be omitted from any resource definition in your terraform manifest.