### PR TITLE
fix: AME-3581 set version to optional

### DIFF
--- a/acloud/resource_cluster.go
+++ b/acloud/resource_cluster.go
@@ -87,7 +87,7 @@ func resourceCluster() *schema.Resource {
 			},
 			"version": {
 				Type:        schema.TypeString,
-				Required:    false,
+				Optional:    true,
 				Description: "Avisi Cloud Kubernetes version of the Cluster",
 			},
 			"cloud_account_identity": {


### PR DESCRIPTION

Fix for:
```
Error: failed to read schema for acloud_cluster.test in registry.terraform.io/avisi-cloud/acloud: provider registry.terraform.io/avisi-cloud/acloud has invalid schema for managed resource type "acloud_cluster", which is a bug in the provider: "version: must set Optional, Required or Computed"
```