### PR TITLE
Populate regions field in cloud profile data source

### DIFF
--- a/acloud/data_source_cloud_profile.go
+++ b/acloud/data_source_cloud_profile.go
@@ -99,5 +99,6 @@ func dataCloudProfileRead(ctx context.Context, d *schema.ResourceData, m interfa
 	d.Set("enabled", cloudProfile.Enabled)
 	d.Set("public", cloudProfile.Public)
 	d.Set("type", cloudProfile.Type)
+	d.Set("regions", cloudProfile.Regions)
 	return nil
 }


### PR DESCRIPTION
## Summary
- return regions when reading a cloud profile

## Testing
- `go test ./...`
- `go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest` *(fails: Forbidden)*
- `go get github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest` *(fails: Forbidden)*


------
https://chatgpt.com/codex/tasks/task_b_68543534b0708332b2b779a602144808