### PR TITLE
fix: license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Avisi Cloud Platform Terraform Provider for managing your Avisi Cloud resources 
 
 ## License
 
-[Apache 2.0 License 2.0](lICENSE)
+[Apache 2.0 License](LICENSE)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- fix broken link to the license in the README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6854353b5df8833298ac3a1d6cce0ba2